### PR TITLE
Fix SharedElement prop type

### DIFF
--- a/src/SharedElement.tsx
+++ b/src/SharedElement.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { View, findNodeHandle, ViewStyle } from 'react-native';
+import { View, findNodeHandle, ViewProps } from 'react-native';
 import { SharedElementNode } from './types';
 
-export type SharedElementProps = ViewStyle & {
+export type SharedElementProps = ViewProps & {
   children: React.ReactNode;
   onNode: (node: SharedElementNode | null) => void;
 };


### PR DESCRIPTION
I noticed that when I tried to put a `style` prop on a `<SharedElement />`, typescript flagged it as an error, even though it works. Furthermore if I add props like `position` or `top` they are not flagged by typescript even though they don't do anything.

It looks like the [intention](https://github.com/IjzerenHein/react-native-shared-element#props) is that any ViewProp will work, but the type is union'd to ViewStyle. I think this commit restores what was intended.