### PR TITLE
Fix error 'Could not find com.android.tools.build:gradle:4.1.3.'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,10 @@ def safeExtGet(prop, fallback) {
 buildscript {
     repositories {
         jcenter()
+        google()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {


### PR DESCRIPTION
Complete error :

Gradle sync failed: Could not find com.android.tools.build:gradle:4.1.3.
				Searched in the following locations:
				- https://jcenter.bintray.com/com/android/tools/build/gradle/4.1.3/gradle-4.1.3.pom
				If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration.
				Required by:
				project :react-native-shared-element