### PR TITLE
fix: Implicit conversion of Obj-C pointer type 'UIColor *' to C pointer

### DIFF
--- a/ios/RNSharedElementStyle.m
+++ b/ios/RNSharedElementStyle.m
@@ -40,7 +40,7 @@
     if ([view isKindOfClass:[RCTView class]]) {
       RCTView* rctView = (RCTView*) view;
       _cornerRadii = [RNSharedElementStyle cornerRadiiFromRCTView: rctView];
-      _borderColor = rctView.borderColor ? [UIColor colorWithCGColor:rctView.borderColor] : [UIColor clearColor];
+      _borderColor = rctView.borderColor ? [UIColor colorWithCGColor:(__bridge CGColorRef _Nonnull)(rctView.borderColor)] : [UIColor clearColor];
       _borderWidth = rctView.borderWidth >= 0.0f ? rctView.borderWidth : 0.0f;
       _backgroundColor = rctView.backgroundColor ? rctView.backgroundColor : [UIColor clearColor];
     } else {


### PR DESCRIPTION
With React-Native 0.65.0 RNSharedElement breaks the build, because implicit conversion of Objective-C pointer type 'UIColor *' to C pointer type 'CGColorRef _Nonnull' (aka 'struct CGColor *') requires a bridged cast.

~~This PR fixes it.~~