### PR TITLE
fix ios use_frameworks building issue

### DIFF
--- a/RNSharedElement.podspec
+++ b/RNSharedElement.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m}"
   s.requires_arc = true
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
as https://github.com/facebook/react-native/issues/29633#issuecomment-694187116, libraries may need to depend on `React-Core` to fix use_frameworks! build errors. please take a look if the change making sense.
well, i am actually trying to fix [the issue](https://github.com/expo/expo/pull/14523#issuecomment-927121182) 😁

