### PR TITLE
[fix] Fix Android build error on react-native 0.67

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'maven'
 
 buildscript {
   // Simple helper that allows the root project to override versions declared by this library.
@@ -14,31 +13,6 @@ buildscript {
 
   dependencies {
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.4.21')}")
-  }
-}
-
-// Upload android library to maven with javadoc and android sources
-configurations {
-  deployerJars
-}
-
-// Creating sources with comments
-task androidSourcesJar(type: Jar) {
-  classifier = 'sources'
-  from android.sourceSets.main.java.srcDirs
-}
-
-// Put the androidSources and javadoc to the artifacts
-artifacts {
-  archives androidSourcesJar
-}
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      configuration = configurations.deployerJars
-      repository(url: mavenLocal().url)
-    }
   }
 }
 


### PR DESCRIPTION
# Why

react-native 0.67 upgrade to gradle 7 which drop `maven` plugin support.

fix #87 

# How

i think this library does not have to publish as aar format, so i just remove all publish related gradle code. if it's necessary, i can update as the packages' change in the pr: https://github.com/expo/expo/pull/16038

# Test Plan

```
npx react-native init RN067 --version 0.67
cd RN067
yarn add react-native-shared-element
cd android
./gradlew :app:assembleDebug
```