### PR TITLE
[feat] Add support for expo-image

### DIFF
--- a/ios/RNSharedElementContent.m
+++ b/ios/RNSharedElementContent.m
@@ -20,9 +20,11 @@
 
 + (BOOL) isKindOfImageView:(UIView*) view
 {
+  NSString* className = NSStringFromClass(view.class);
   return (
           [view isKindOfClass:[UIImageView class]] ||
-          [NSStringFromClass(view.class) isEqualToString:@"RCTImageView"]
+          [className isEqualToString:@"RCTImageView"] ||
+          [className isEqualToString:@"ExpoImage.ImageView"]
           );
 }
 
@@ -30,10 +32,9 @@
 {
   if ([view isKindOfClass:[UIImageView class]]) {
     return (UIImageView*) view;
-  } else if ([NSStringFromClass(view.class) isEqualToString:@"RCTImageView"]) {
-    // As of react-native 0.60, RCTImageView is no longer inherited from
-    // UIImageView, but has a UIImageView as child. That will cause this code-path
-    // to be executed, where the first child view is returned.
+  } else if ([RNSharedElementContent isKindOfImageView:view]) {
+    // Both react-native and expo-image have a UIImageView
+    // as the first child.
     return (UIImageView*) view.subviews.firstObject;
   } else {
     // Error


### PR DESCRIPTION
Adds support for expo-image. On Android this was already working, but on iOS two issues were identified:
- The underlying UIImageView was not recognized (fixed by this PR)
- The `contentMode` (resizeMode) is not recognized (open issue, needs to be fixed in expo-image)