### PR TITLE
Pullrequests/akramloginext/bugfix#281 on react navigation shared element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [0.8.9](https://github.com/IjzerenHein/react-native-shared-element/compare/v0.8.8...v0.8.9) (2023-11-17)
+
+### Bug Fixes
+
+- **android** [fix] Fix exception on Android when drawable is null. [(#121)](https://github.com/IjzerenHein/react-native-shared-element/pull/121) (thanks @akramloginext)
+
 # [0.8.8](https://github.com/IjzerenHein/react-native-shared-element/compare/v0.8.7...v0.8.8) (2023-01-02)
 
 ### Bug Fixes

--- a/android/src/main/java/com/ijzerenhein/sharedelement/RNSharedElementDrawable.java
+++ b/android/src/main/java/com/ijzerenhein/sharedelement/RNSharedElementDrawable.java
@@ -224,71 +224,71 @@ class RNSharedElementDrawable extends Drawable {
   private void drawReactImageView(Canvas canvas) {
     // TODO FIX IMAGE STRETCH ISSUE WHEN IMAGE DOESN'T FILL
     // ENTIRE CANVAS
-        ReactImageView imageView = (ReactImageView) mContent.view;
-        RNSharedElementStyle style = mStyle;
-        GenericDraweeHierarchy hierarchy = imageView.getHierarchy();
-        Drawable drawable = hierarchy.getTopLevelDrawable();
-    if (drawable != null) {
-      // Backup current props
-        Rect oldBounds = new Rect(drawable.getBounds());
-        ScaleType oldScaleType = hierarchy.getActualImageScaleType();
-        RoundingParams oldRoundingParams = hierarchy.getRoundingParams();
-        Drawable oldBackgroundImage = null; //hierarchy.getBackgroundImage();
-        int oldFadeDuration = hierarchy.getFadeDuration();
+    ReactImageView imageView = (ReactImageView) mContent.view;
+    RNSharedElementStyle style = mStyle;
+    GenericDraweeHierarchy hierarchy = imageView.getHierarchy();
+    Drawable drawable = hierarchy.getTopLevelDrawable();
+    if (drawable == null) return;
 
-        // Configure drawable
-        drawable.setBounds(getBounds());
-        hierarchy.setActualImageScaleType(style.scaleType);
-        RoundingParams roundingParams = new RoundingParams();
-        roundingParams.setBorderColor(style.borderColor);
-        roundingParams.setBorderWidth(style.borderWidth);
-        roundingParams.setRoundingMethod(RoundingParams.RoundingMethod.BITMAP_ONLY);
-        roundingParams.setCornersRadii(
-                style.borderTopLeftRadius,
-                style.borderTopRightRadius,
-                style.borderBottomRightRadius,
-                style.borderBottomLeftRadius
-        );
-        hierarchy.setRoundingParams(roundingParams);
-        hierarchy.setBackgroundImage(null);
-        hierarchy.setFadeDuration(0);
+    // Backup current props
+    Rect oldBounds = new Rect(drawable.getBounds());
+    ScaleType oldScaleType = hierarchy.getActualImageScaleType();
+    RoundingParams oldRoundingParams = hierarchy.getRoundingParams();
+    Drawable oldBackgroundImage = null; //hierarchy.getBackgroundImage();
+    int oldFadeDuration = hierarchy.getFadeDuration();
 
-        // Draw!
-        drawable.draw(canvas);
+    // Configure drawable
+    drawable.setBounds(getBounds());
+    hierarchy.setActualImageScaleType(style.scaleType);
+    RoundingParams roundingParams = new RoundingParams();
+    roundingParams.setBorderColor(style.borderColor);
+    roundingParams.setBorderWidth(style.borderWidth);
+    roundingParams.setRoundingMethod(RoundingParams.RoundingMethod.BITMAP_ONLY);
+    roundingParams.setCornersRadii(
+            style.borderTopLeftRadius,
+            style.borderTopRightRadius,
+            style.borderBottomRightRadius,
+            style.borderBottomLeftRadius
+    );
+    hierarchy.setRoundingParams(roundingParams);
+    hierarchy.setBackgroundImage(null);
+    hierarchy.setFadeDuration(0);
 
-        // Restore props
-        hierarchy.setFadeDuration(oldFadeDuration);
-        hierarchy.setBackgroundImage(oldBackgroundImage);
-        hierarchy.setRoundingParams(oldRoundingParams);
-        hierarchy.setActualImageScaleType(oldScaleType);
-        drawable.setBounds(oldBounds);
-    }
+    // Draw!
+    drawable.draw(canvas);
+
+    // Restore props
+    hierarchy.setFadeDuration(oldFadeDuration);
+    hierarchy.setBackgroundImage(oldBackgroundImage);
+    hierarchy.setRoundingParams(oldRoundingParams);
+    hierarchy.setActualImageScaleType(oldScaleType);
+    drawable.setBounds(oldBounds);
   }
 
   private void drawImageView(Canvas canvas) {
     ImageView imageView = (ImageView) mContent.view;
     RNSharedElementStyle style = mStyle;
     Drawable drawable = imageView.getDrawable();
-    if (drawable != null) {
-        // Backup current props
-        Rect oldBounds = new Rect(drawable.getBounds());
+    if (drawable == null) return;
 
-        // Configure drawable
-        int width = (int) mContent.size.right;
-        int height = (int) mContent.size.bottom;
-        drawable.setBounds(0, 0, width, height);
-        Matrix matrix = new Matrix();
-        style.scaleType.getTransform(matrix, getBounds(), width, height, 0.5f, 0.5f);
+    // Backup current props
+    Rect oldBounds = new Rect(drawable.getBounds());
 
-        // Draw!
-        int saveCount = canvas.save();
-        canvas.concat(matrix);
-        drawable.draw(canvas);
-        canvas.restoreToCount(saveCount);
+    // Configure drawable
+    int width = (int) mContent.size.right;
+    int height = (int) mContent.size.bottom;
+    drawable.setBounds(0, 0, width, height);
+    Matrix matrix = new Matrix();
+    style.scaleType.getTransform(matrix, getBounds(), width, height, 0.5f, 0.5f);
 
-        // Restore props
-        drawable.setBounds(oldBounds);
-    }
+    // Draw!
+    int saveCount = canvas.save();
+    canvas.concat(matrix);
+    drawable.draw(canvas);
+    canvas.restoreToCount(saveCount);
+
+    // Restore props
+    drawable.setBounds(oldBounds);
   }
 
   private void drawPlainView(Canvas canvas) {

--- a/android/src/main/java/com/ijzerenhein/sharedelement/RNSharedElementDrawable.java
+++ b/android/src/main/java/com/ijzerenhein/sharedelement/RNSharedElementDrawable.java
@@ -224,70 +224,71 @@ class RNSharedElementDrawable extends Drawable {
   private void drawReactImageView(Canvas canvas) {
     // TODO FIX IMAGE STRETCH ISSUE WHEN IMAGE DOESN'T FILL
     // ENTIRE CANVAS
+        ReactImageView imageView = (ReactImageView) mContent.view;
+        RNSharedElementStyle style = mStyle;
+        GenericDraweeHierarchy hierarchy = imageView.getHierarchy();
+        Drawable drawable = hierarchy.getTopLevelDrawable();
+    if (drawable != null) {
+      // Backup current props
+        Rect oldBounds = new Rect(drawable.getBounds());
+        ScaleType oldScaleType = hierarchy.getActualImageScaleType();
+        RoundingParams oldRoundingParams = hierarchy.getRoundingParams();
+        Drawable oldBackgroundImage = null; //hierarchy.getBackgroundImage();
+        int oldFadeDuration = hierarchy.getFadeDuration();
 
-    ReactImageView imageView = (ReactImageView) mContent.view;
-    RNSharedElementStyle style = mStyle;
-    GenericDraweeHierarchy hierarchy = imageView.getHierarchy();
-    Drawable drawable = hierarchy.getTopLevelDrawable();
+        // Configure drawable
+        drawable.setBounds(getBounds());
+        hierarchy.setActualImageScaleType(style.scaleType);
+        RoundingParams roundingParams = new RoundingParams();
+        roundingParams.setBorderColor(style.borderColor);
+        roundingParams.setBorderWidth(style.borderWidth);
+        roundingParams.setRoundingMethod(RoundingParams.RoundingMethod.BITMAP_ONLY);
+        roundingParams.setCornersRadii(
+                style.borderTopLeftRadius,
+                style.borderTopRightRadius,
+                style.borderBottomRightRadius,
+                style.borderBottomLeftRadius
+        );
+        hierarchy.setRoundingParams(roundingParams);
+        hierarchy.setBackgroundImage(null);
+        hierarchy.setFadeDuration(0);
 
-    // Backup current props
-    Rect oldBounds = new Rect(drawable.getBounds());
-    ScaleType oldScaleType = hierarchy.getActualImageScaleType();
-    RoundingParams oldRoundingParams = hierarchy.getRoundingParams();
-    Drawable oldBackgroundImage = null; //hierarchy.getBackgroundImage();
-    int oldFadeDuration = hierarchy.getFadeDuration();
+        // Draw!
+        drawable.draw(canvas);
 
-    // Configure drawable
-    drawable.setBounds(getBounds());
-    hierarchy.setActualImageScaleType(style.scaleType);
-    RoundingParams roundingParams = new RoundingParams();
-    roundingParams.setBorderColor(style.borderColor);
-    roundingParams.setBorderWidth(style.borderWidth);
-    roundingParams.setRoundingMethod(RoundingParams.RoundingMethod.BITMAP_ONLY);
-    roundingParams.setCornersRadii(
-            style.borderTopLeftRadius,
-            style.borderTopRightRadius,
-            style.borderBottomRightRadius,
-            style.borderBottomLeftRadius
-    );
-    hierarchy.setRoundingParams(roundingParams);
-    hierarchy.setBackgroundImage(null);
-    hierarchy.setFadeDuration(0);
-
-    // Draw!
-    drawable.draw(canvas);
-
-    // Restore props
-    hierarchy.setFadeDuration(oldFadeDuration);
-    hierarchy.setBackgroundImage(oldBackgroundImage);
-    hierarchy.setRoundingParams(oldRoundingParams);
-    hierarchy.setActualImageScaleType(oldScaleType);
-    drawable.setBounds(oldBounds);
+        // Restore props
+        hierarchy.setFadeDuration(oldFadeDuration);
+        hierarchy.setBackgroundImage(oldBackgroundImage);
+        hierarchy.setRoundingParams(oldRoundingParams);
+        hierarchy.setActualImageScaleType(oldScaleType);
+        drawable.setBounds(oldBounds);
+    }
   }
 
   private void drawImageView(Canvas canvas) {
     ImageView imageView = (ImageView) mContent.view;
     RNSharedElementStyle style = mStyle;
     Drawable drawable = imageView.getDrawable();
+    if (drawable != null) {
+        // Backup current props
+        Rect oldBounds = new Rect(drawable.getBounds());
 
-    // Backup current props
-    Rect oldBounds = new Rect(drawable.getBounds());
+        // Configure drawable
+        int width = (int) mContent.size.right;
+        int height = (int) mContent.size.bottom;
+        drawable.setBounds(0, 0, width, height);
+        Matrix matrix = new Matrix();
+        style.scaleType.getTransform(matrix, getBounds(), width, height, 0.5f, 0.5f);
 
-    // Configure drawable
-    int width = (int) mContent.size.right;
-    int height = (int) mContent.size.bottom;
-    drawable.setBounds(0, 0, width, height);
-    Matrix matrix = new Matrix();
-    style.scaleType.getTransform(matrix, getBounds(), width, height, 0.5f, 0.5f);
+        // Draw!
+        int saveCount = canvas.save();
+        canvas.concat(matrix);
+        drawable.draw(canvas);
+        canvas.restoreToCount(saveCount);
 
-    // Draw!
-    int saveCount = canvas.save();
-    canvas.concat(matrix);
-    drawable.draw(canvas);
-    canvas.restoreToCount(saveCount);
-
-    // Restore props
-    drawable.setBounds(oldBounds);
+        // Restore props
+        drawable.setBounds(oldBounds);
+    }
   }
 
   private void drawPlainView(Canvas canvas) {

--- a/android/src/main/java/com/ijzerenhein/sharedelement/RNSharedElementDrawable.java
+++ b/android/src/main/java/com/ijzerenhein/sharedelement/RNSharedElementDrawable.java
@@ -224,6 +224,7 @@ class RNSharedElementDrawable extends Drawable {
   private void drawReactImageView(Canvas canvas) {
     // TODO FIX IMAGE STRETCH ISSUE WHEN IMAGE DOESN'T FILL
     // ENTIRE CANVAS
+
     ReactImageView imageView = (ReactImageView) mContent.view;
     RNSharedElementStyle style = mStyle;
     GenericDraweeHierarchy hierarchy = imageView.getHierarchy();

--- a/android/src/main/java/com/ijzerenhein/sharedelement/RNSharedElementTransition.java
+++ b/android/src/main/java/com/ijzerenhein/sharedelement/RNSharedElementTransition.java
@@ -183,6 +183,9 @@ public class RNSharedElementTransition extends ViewGroup {
 
     // Get parent offset
     View parent = (View) getParent();
+    if(parent == null){
+      return;
+    }
     parent.getLocationInWindow(mParentOffset);
 
     // Get styles

--- a/android/src/main/java/com/ijzerenhein/sharedelement/RNSharedElementTransition.java
+++ b/android/src/main/java/com/ijzerenhein/sharedelement/RNSharedElementTransition.java
@@ -183,9 +183,7 @@ public class RNSharedElementTransition extends ViewGroup {
 
     // Get parent offset
     View parent = (View) getParent();
-    if(parent == null){
-      return;
-    }
+    if (parent == null) return;
     parent.getLocationInWindow(mParentOffset);
 
     // Get styles


### PR DESCRIPTION
![gif](https://media.giphy.com/media/6mGzvKGJGsYH6/giphy.gif)

Reformat of #120, thanks @akramloginext

This PR attempts to fix the dreaded `attempt to invoke virtual method android.graphics.rect.android.graphics.drawables.getbounds() on a null object reference` issue.
https://github.com/IjzerenHein/react-navigation-shared-element/issues/281




